### PR TITLE
Only finding the latest successful build when et_version is null

### DIFF
--- a/vars/prepare_et_with_rpm_by_ansible.groovy
+++ b/vars/prepare_et_with_rpm_by_ansible.groovy
@@ -49,7 +49,7 @@ def call(String et_server, String et_version, String errata_fetch_brew_build='fa
             source RC_CI-master/auto_testing_CI/CI_Shell_common_usage.sh
             install_scripts_env
 
-            if [[ "${get_the_target_build}" == "true" ]]
+            if [[ -z "${et_version}" ]]
             then
               et_build_id_and_branch=$(python RC_CI-master/auto_testing_CI/talk_to_rc_jenkins_to_get_the_target_build.py ${dev_jenkins_user} ${dev_jenkins_user_token} ${dev_jenkins_job})
               if [[ ${et_build_id_and_branch} =~ 'There is no [success] builds today' ]]
@@ -59,6 +59,7 @@ def call(String et_server, String et_version, String errata_fetch_brew_build='fa
               fi
               echo "${et_build_id_and_branch}" | cut -d " " -f 1 > et_build_name_or_id
               echo "${et_build_id_and_branch}" | cut -d " " -f 3 > et_branch
+              export et_build_name_or_id=$(cat et_build_name_or_id)
             fi
 
             RC_CI-master/auto_testing_CI/prepare_et_server_with_rpm_by_ansible.sh


### PR DESCRIPTION
Then we can ignore the conflused parameter 'get_the_target_build'